### PR TITLE
chore: bump current package version

### DIFF
--- a/crates/http-source/hub/package-meta.yaml
+++ b/crates/http-source/hub/package-meta.yaml
@@ -1,7 +1,7 @@
 ---
 package_format_version: "0.2"
 name: http-source
-version: 0.1.0
+version: 0.1.1
 group: infinyon
 description: HTTP source connector
 license: Apache2


### PR DESCRIPTION
Since 0.1.0 is released, the current version set to 0.1.1